### PR TITLE
make local pip install work without -e

### DIFF
--- a/pynita/data_reader/data_loader.py
+++ b/pynita/data_reader/data_loader.py
@@ -11,7 +11,7 @@ Copyright (c)
 import pandas as pd
 import numpy as np
 from osgeo import gdal
-from pynita.utils import general 
+from ..utils import general 
 
 class dataLoader:
     """The DataLoader class 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='pynita',
       version='0.1',
@@ -7,12 +7,12 @@ setup(name='pynita',
       author='Leyang Feng',
       author_email='feng@american.edu',
       license='MIT',
-      packages=['pynita'],
+      packages=find_packages(),
       install_requires=['numpy>=1.14',
-	                    'scipy>=1.0', 
-						'tqdm>=4.23',
-						'gdal>=2.1',
-						'pandas>=0.22',
-						'configobj>=5.0',
-						'matplotlib>=2.1'],
-	  zip_safe=False)
+                        'scipy>=1.0',
+                        'tqdm>=4.23',
+                        'gdal>=2.1',
+                        'pandas>=0.22',
+                        'configobj>=5.0',
+                        'matplotlib>=2.1'],
+      zip_safe=False)


### PR DESCRIPTION
The different behavior observed for `pip install -e .` and `pip install .` for the pynita package was due to how subpackages get added to the search path. For the local install to work without the `-e` flag, all the packages (including subpackages!) have to be identified in setup.py. That's good practice and a pain, which is why `setuptools.find_packages()` exists.

Also '..' goes to a parent package from a subpackage.

And ... pleasing indentation :)